### PR TITLE
create token with all params and add a test

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clanhr/auth "0.4.1"
+(defproject clanhr/auth "0.4.2"
   :description "ClanHR's Auth Library"
   :url "https://github.com/clanhr/auth"
   :license {:name "The MIT License"

--- a/src/clanhr/auth/core.clj
+++ b/src/clanhr/auth/core.clj
@@ -24,7 +24,7 @@
 (defn token-for
   "Creates a token for a user"
   [args]
-  (-> (build-claim (args :user))
+  (-> (build-claim args)
       jwt
       (sign :HS256 (secret))
       to-str))

--- a/src/clanhr/auth/core.clj
+++ b/src/clanhr/auth/core.clj
@@ -22,7 +22,7 @@
    :iat (now)})
 
 (defn token-for
-  "Creates a token for a user"
+  "Creates a token for given args"
   [args]
   (-> (build-claim args)
       jwt

--- a/test/clanhr/auth/auth_middleware_test.clj
+++ b/test/clanhr/auth/auth_middleware_test.clj
@@ -25,3 +25,16 @@
         (let [response ((auth-middleware/run handler) (request :get "/"))]
           (is (= 401
                  (:status response))))))))
+
+(deftest extract-data-test
+  (let [data {:user "bob_the_builder"
+              :password "spoon"
+              :email "bubu@mail.com"
+              :account "account"
+              :user-id "user_id"}
+        token (auth/token-for data)
+        result-valid (auth-middleware/valid? token)
+        result (auth-middleware/add-principal {} result-valid)]
+    (is (= (:user-id data ) (get-in result [:principal :user-id])))
+    (is (= (:account data ) (get-in result [:principal :account])))
+    (is (= (:email data ) (get-in result [:principal :email])))))

--- a/test/clanhr/auth/core_test.clj
+++ b/test/clanhr/auth/core_test.clj
@@ -4,13 +4,14 @@
 
 (deftest generate-token-test
   (testing "generation"
-    (let [token (auth/token-for {:user "bob_the_builder" :password "spoon"})]
+    (let [data {:user "bob_the_builder" :password "spoon"}
+          token (auth/token-for data)]
       (is token)
       (testing "verify")
         (let [result (auth/parse token)]
           (is result)
           (is (auth/valid? result))
-          (is (= "bob_the_builder" (auth/principal result)))))))
+          (is (= data (auth/principal result)))))))
 
 (deftest build-claim-test
   (let [user {:user "bob_the_builder"}]


### PR DESCRIPTION
Talvez isto vá criar bugs nos serviços.. acho que vai ser preciso mexer nos serviços.. estavamos a criar o token apenas com 

``` clojure
(defn token-for
  "Creates a token for a user"
  [args]
  (-> (build-claim (:user args))
      jwt
      (sign :HS256 (secret))
      to-str))
```

o que não fazia sentido nenhum.. eu quero criar um token com todos os dados que me passam..

https://github.com/clanhr/mothership/issues/372
