### PR TITLE
Fix get-roles on testing env

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clanhr/auth "1.11.1"
+(defproject clanhr/auth "1.11.2"
   :description "ClanHR's Auth Library"
   :url "https://github.com/clanhr/auth"
   :license {:name "The MIT License"

--- a/src/clanhr/auth/authorized.clj
+++ b/src/clanhr/auth/authorized.clj
@@ -24,7 +24,7 @@
       (clanhr-api/http-get {:service :directory-api
                             :path (str "/user/" (:user-id context) "/roles")
                             :token (:token context)})
-      (result/success))))
+      (go (result/success)))))
 
 (defmulti authorized?
   (fn [context]

--- a/test/clanhr/auth/authorized_test.clj
+++ b/test/clanhr/auth/authorized_test.clj
@@ -29,7 +29,6 @@
 (deftest specific-user-has-access-test
   (testing "has access"
     (let [context {:user {:system {:roles ["hrmanager"]}}
-                   :get-user-roles-result (result/success)
                    :action :notifications-access}
           result (<!! (auth/authorized? context))]
       (is (result/succeeded? result))
@@ -45,7 +44,6 @@
 
   (testing "do not have access"
     (let [context {:user {:system {:roles ["waza"]}}
-                   :get-user-roles-result (result/success)
                    :action :notifications-access}
           result (<!! (auth/authorized? context))]
       (is (result/forbidden? result)))))


### PR DESCRIPTION
On testing env I was returning a result, when I should return a channel.
Now properly tested.
