### PR TITLE
Calculate token if needed

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clanhr/auth "1.11.2"
+(defproject clanhr/auth "1.11.3"
   :description "ClanHR's Auth Library"
   :url "https://github.com/clanhr/auth"
   :license {:name "The MIT License"

--- a/src/clanhr/auth/auth_middleware.clj
+++ b/src/clanhr/auth/auth_middleware.clj
@@ -18,7 +18,7 @@
 
 (defn add-principal
   "Adds principal info to the request"
-  [context result]
+  [context result token]
   (let [email (get-in result [:claims :iss :email])
         account (get-in result [:claims :iss :account])
         account-id (get-in result [:claims :iss :account-id])
@@ -26,7 +26,8 @@
     (assoc context :principal {:email email
                                :account account
                                :account-id account-id
-                               :user-id user-id})))
+                               :user-id user-id}
+                   :token token)))
 
 (defn run
   "Performs validation"
@@ -36,5 +37,5 @@
           result (valid? token)]
       (if (result/succeeded? result)
         (handler (-> context
-                     (add-principal result)))
+                     (add-principal result token)))
         (reply/unauthorized)))))

--- a/test/clanhr/auth/auth_middleware_test.clj
+++ b/test/clanhr/auth/auth_middleware_test.clj
@@ -52,7 +52,7 @@
               :password "spoon"}
         token (auth/token-for data)
         result-valid (auth-middleware/valid? token)
-        result (auth-middleware/add-principal {} result-valid)]
+        result (auth-middleware/add-principal {} result-valid "some-token")]
     (is (= (get-in data [:user :user-id]) (get-in result [:principal :user-id])))
     (is (= (get-in data [:user :account]) (get-in result [:principal :account])))
     (is (= (get-in data [:user :account-id]) (get-in result [:principal :account-id])))


### PR DESCRIPTION
Sometimes we pass a user to validate credentials. However, now we need
to communicate with another service and we need the token, that the user
does not have. So, if the token is not on the context, a new token is
produced.

Also added the token to context on the middleware.
