### PR TITLE
Remove shared deps

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,17 +1,17 @@
-(defproject clanhr/auth "1.11.4"
+(defproject clanhr/auth "1.11.5"
   :description "ClanHR's Auth Library"
   :url "https://github.com/clanhr/auth"
   :license {:name "The MIT License"
             :url "file://LICENSE"}
-  :dependencies.edn "https://raw.githubusercontent.com/clanhr/dependencies/master/dependencies.edn"
-  :dependencies []
-
-  :dependency-sets [:clojure
-                    :security
-                    :common
-                    :ring
-                    :clanhr]
-  :plugins [[lein-environ "1.0.0"]
-            [clanhr/shared-deps "0.2.6"]]
+  :dependencies[[org.clojure/clojure "1.8.0"]
+                [environ "1.0.2"]
+                [ring/ring-core "1.4.0"]
+                [ring/ring-mock "0.3.0"]
+                [clanhr/result "0.11.0"]
+                [clanhr/reply "0.11.0"]
+                [clanhr/clanhr-api "1.7.3"]
+                [clj-jwt "0.1.1"]
+                [clj-time "0.11.0"]]
+  :plugins [[lein-environ "1.0.2"]]
   :profiles {:test {:env {:secret "test_secret"}}
              :dev {:env {:secret "dev_secret"}}})


### PR DESCRIPTION
Motivation:

Shared deps brings a heavy burden on a project. lein deps :tree takes 60s with
shared deps, and 3s without it. So we'll start using shared deps only on the
services.
