### PR TITLE
Also consider api_key as token source

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clanhr/auth "1.11.5"
+(defproject clanhr/auth "1.12.0"
   :description "ClanHR's Auth Library"
   :url "https://github.com/clanhr/auth"
   :license {:name "The MIT License"

--- a/src/clanhr/auth/auth_middleware.clj
+++ b/src/clanhr/auth/auth_middleware.clj
@@ -14,7 +14,8 @@
   (or
     (get-header context "auth-token")
     (get-header context "x-clanhr-auth-token")
-    (get-in context [:query-params "token"])))
+    (get-in context [:query-params "token"])
+    (get-in context [:query-params "api_key"])))
 
 (defn add-principal
   "Adds principal info to the request"

--- a/test/clanhr/auth/auth_middleware_test.clj
+++ b/test/clanhr/auth/auth_middleware_test.clj
@@ -36,6 +36,14 @@
           (is (= 200
                  (:status response))))))
 
+    (testing "should pass an api_key as query param"
+      (letfn [(handler [request]
+                response-hash)]
+        (let [req (assoc (request :get "/") :query-params {"api_key" token})
+              response ((auth-middleware/run handler) req)]
+          (is (= 200
+                 (:status response))))))
+
     (testing "should fail"
       (letfn [(handler [request]
                 response-hash)]


### PR DESCRIPTION
Motivation:

The swagger ui uses _api_key_ as a query string param for auth. Because
I don't know how to change that, we're also supporting this param.
