### PR TITLE
New auth rules

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clanhr/auth "1.12.0"
+(defproject clanhr/auth "1.13.0"
   :description "ClanHR's Auth Library"
   :url "https://github.com/clanhr/auth"
   :license {:name "The MIT License"

--- a/project.clj
+++ b/project.clj
@@ -13,5 +13,7 @@
                 [clj-jwt "0.1.1"]
                 [clj-time "0.11.0"]]
   :plugins [[lein-environ "1.0.2"]]
-  :profiles {:test {:env {:secret "test_secret"}}
+  :aliases {"autotest" ["trampoline" "with-profile" "+test" "test-refresh"]}
+  :profiles {:test {:env {:secret "test_secret"}
+                    :plugins [[com.jakemccrary/lein-test-refresh "0.15.0"]]}
              :dev {:env {:secret "dev_secret"}}})

--- a/src/clanhr/auth/authorization_rules.clj
+++ b/src/clanhr/auth/authorization_rules.clj
@@ -13,6 +13,7 @@
    :notifications-access (:full-access profile)
    :reports-access (:board-member-manager profile)
    :can-manage-absences (:board-member profile)
+   :change-absence-state (conj (:board-member profile) "approver")
    :settings-access (:board-member profile)
    :can-see-full-user-info (:board-member profile)
    :delete-user (:board-member profile)})

--- a/src/clanhr/auth/authorized.clj
+++ b/src/clanhr/auth/authorized.clj
@@ -52,9 +52,8 @@
           context (assoc context :user-id (get-in context [:user :_id])
                                  :token (get-token context (get-in context [:user])))]
       (result/enforce-let [token? (token-present context)
-                           auth-result (authorization-rules/run (:action context) roles)
-                           subscription-enabled? (<! (get-roles context))]
-        auth-result))))
+                           result (<! (get-roles context))]
+        (authorization-rules/run (:action context) roles)))))
 
 (defmethod authorized? :default [context]
   (go

--- a/src/clanhr/auth/roles_for.clj
+++ b/src/clanhr/auth/roles_for.clj
@@ -1,0 +1,19 @@
+(ns ^{:added "1.13.0" :author "Pedro Pereira Santos"}
+  clanhr.auth.roles-for
+  "Logic that build specific roles for relations between two users"
+  (:require [result.core :as result]))
+
+(defn approver
+  "Returns the approver role if the user is an approver of other-user"
+  [user other-user]
+  (if-let [user-id (:_id user)]
+    (if (or (= user-id (get-in other-user [:company-data :approver-id]))
+            (some #{user-id} (get-in other-user [:company-data :manager-ids])))
+      "approver")))
+
+(defn run
+  "Returns specific roles that represent the relation between user and other-user"
+  [{:keys [user other-user]}]
+  (->> [(approver user other-user)]
+       (filter identity)
+       (result/success)))

--- a/test/clanhr/auth/authorized_test.clj
+++ b/test/clanhr/auth/authorized_test.clj
@@ -47,3 +47,9 @@
                    :action :notifications-access}
           result (<!! (auth/authorized? context))]
       (is (result/forbidden? result)))))
+
+(deftest get-url-test
+  (is (= (auth/get-url {:user-id "1"})
+         "/user/1/roles"))
+  (is (= (auth/get-url {:user-id "1" :other-user-id "2"})
+         "/user/1/roles?other=2")))

--- a/test/clanhr/auth/roles_for_test.clj
+++ b/test/clanhr/auth/roles_for_test.clj
@@ -1,0 +1,24 @@
+(ns clanhr.auth.roles_for_test
+  (:use clojure.test)
+  (:require [clanhr.auth.roles-for :as roles-for]
+            [result.core :as result]))
+
+(deftest approver-test
+  (testing "from manager-ids"
+    (let [user {:_id "1"}
+          other-user {:company-data {:manager-ids ["1"]}}]
+      (is (= "approver" (roles-for/approver user other-user)))
+      (is (= nil (roles-for/approver other-user user)))))
+  (testing "from approver-id"
+    (let [user {:_id "1"}
+          other-user {:company-data {:approver-id "1"}}]
+      (is (= "approver" (roles-for/approver user other-user)))
+      (is (= nil (roles-for/approver other-user user))))))
+
+(deftest run-test
+  (let [user {:_id "1"}
+        other-user {:company-data {:manager-ids ["1"]}}
+        result (roles-for/run {:user user :other-user other-user})]
+    (is (result/succeeded? result))
+    (is (= ["approver"] (:data result)))))
+


### PR DESCRIPTION
Added `roles-for` that returns specific roles that a main user has over
another user.

Also consider this new rule on authorized.

https://github.com/clanhr/mothership/issues/1617
