### PR TITLE
Use cached roles and new roles

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clanhr/auth "1.13.0"
+(defproject clanhr/auth "1.13.1"
   :description "ClanHR's Auth Library"
   :url "https://github.com/clanhr/auth"
   :license {:name "The MIT License"

--- a/src/clanhr/auth/authorized.clj
+++ b/src/clanhr/auth/authorized.clj
@@ -63,7 +63,8 @@
                                  :token (get-token context (get-in context [:user])))]
       (result/enforce-let [token? (token-present context)
                            result (<! (get-roles context))]
-        (authorization-rules/run (:action context) roles)))))
+        (authorization-rules/run (:action context)
+                                 (concat roles (:roles result)))))))
 
 (defmethod authorized? :default [context]
   (go


### PR DESCRIPTION
By ignoring the roles on the cached user, we had a lot of tests
failing... so this is a compromised solution. If we have test roles,
lets also call the get-roles fn and concat them. This way the action
will still match.
