### PR TITLE
Properly handle system tokens

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clanhr/auth "1.17.0"
+(defproject clanhr/auth "1.18.0"
   :description "ClanHR's Auth Library"
   :url "https://github.com/clanhr/auth"
   :license {:name "The MIT License"

--- a/src/clanhr/auth/auth_middleware.clj
+++ b/src/clanhr/auth/auth_middleware.clj
@@ -23,10 +23,12 @@
   (let [email (get-in result [:claims :iss :email])
         account (get-in result [:claims :iss :account])
         account-id (get-in result [:claims :iss :account-id])
-        user-id (get-in result [:claims :iss :user-id])]
+        user-id (get-in result [:claims :iss :user-id])
+        system? (boolean (get-in result [:claims :iss :system]))]
     (assoc context :principal {:email email
                                :account account
                                :account-id account-id
+                               :system system?
                                :user-id user-id}
                    :token token)))
 

--- a/src/clanhr/auth/core.clj
+++ b/src/clanhr/auth/core.clj
@@ -33,6 +33,11 @@
                       :account account-id
                       :user-id user-id}})))
 
+(defn system-token
+  "Creates a tokens used by the system/services to communicate with each other"
+  []
+  (token-for {:user {:name "clanhr-system" :system true}}))
+
 (defn parse
   "Parse token"
   [token]

--- a/test/clanhr/auth/auth_middleware_test.clj
+++ b/test/clanhr/auth/auth_middleware_test.clj
@@ -1,7 +1,7 @@
 (ns clanhr.auth.auth-middleware-test
-  (require [clanhr.auth.auth-middleware :as auth-middleware]
-           [clanhr.auth.core :as auth])
-  (use clojure.test
+  (:require [clanhr.auth.auth-middleware :as auth-middleware]
+            [clanhr.auth.core :as auth])
+  (:use clojure.test
         ring.mock.request))
 
 (deftest auth-test
@@ -43,6 +43,15 @@
               response ((auth-middleware/run handler) req)]
           (is (= 200
                  (:status response))))))
+
+    (testing "should pass system tokens"
+      (letfn [(handler [request]
+                (is (true? (get-in request [:principal :system])))
+                response-hash)]
+        (let [token (auth/system-token)
+              req (assoc (request :get "/") :query-params {"token" token})
+              response ((auth-middleware/run handler) req)]
+          (is (= 200 (:status response))))))
 
     (testing "should fail"
       (letfn [(handler [request]


### PR DESCRIPTION
Sometimes we need services to communicate, but we don't have a user. For 
example, the `worker` can as the `directory-api` to update balances, but it
does't have a user token.

This patch adds a fn to create a system token and tests that the auth 
middleware properly considers it.

Ref: https://github.com/clanhr/mothership/issues/1740