### PR TITLE
Properly handle invalid JWT JSON

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,18 +1,18 @@
-(defproject clanhr/auth "1.21.0"
+(defproject clanhr/auth "1.22.0"
   :description "ClanHR's Auth Library"
   :url "https://github.com/clanhr/auth"
   :license {:name "The MIT License"
             :url "file://LICENSE"}
   :dependencies[[org.clojure/clojure "1.8.0"]
-                [environ "1.0.2"]
-                [ring/ring-core "1.4.0"]
+                [environ "1.1.0"]
+                [ring/ring-core "1.5.0"]
                 [ring/ring-mock "0.3.0"]
-                [clanhr/result "0.11.0"]
-                [clanhr/reply "0.11.0"]
-                [clanhr/clanhr-api "1.7.3"]
+                [clanhr/result "0.16.0"]
+                [clanhr/reply "1.1.0"]
+                [clanhr/clanhr-api "1.10.1"]
                 [clj-jwt "0.1.1"]
-                [clj-time "0.11.0"]]
-  :plugins [[lein-environ "1.0.2"]]
+                [clj-time "0.12.2"]]
+  :plugins [[lein-environ "1.1.0"]]
   :aliases {"autotest" ["trampoline" "with-profile" "+test" "test-refresh"]}
   :profiles {:test {:env {:secret "test_secret"}
                     :plugins [[com.jakemccrary/lein-test-refresh "0.15.0"]]}

--- a/src/clanhr/auth/user_validator.clj
+++ b/src/clanhr/auth/user_validator.clj
@@ -11,10 +11,13 @@
 (defn run
   "Validate json web token"
   [token]
-  (if token
-    (let [parsed-token (auth/parse token)
-          is-valid? (auth/valid? parsed-token)]
-      (if is-valid?
-        (result/success parsed-token)
-        (result/failure)))
-    (result/failure)))
+  (try
+    (if token
+      (let [parsed-token (auth/parse token)
+            is-valid? (auth/valid? parsed-token)]
+        (if is-valid?
+          (result/success parsed-token)
+          (result/failure)))
+      (result/failure))
+    (catch Exception e
+      (result/exception e))))

--- a/test/clanhr/auth/user_validator_test.clj
+++ b/test/clanhr/auth/user_validator_test.clj
@@ -15,4 +15,9 @@
     (testing "should failed"
       (let [another-token "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.TJVA95OrM7E2cBab30RMHrHDcEfxjoYZgeFONFh7HgQ"
             validate-result (validate-token/run another-token)]
-        (is (result/failed? validate-result))))))))
+        (is (result/failed? validate-result))))
+    (testing "invalid data"
+      (let [another-token "�"
+            result (validate-token/run another-token)]
+        (is (result/failed? result))
+        (is (result/exception? result))))))))


### PR DESCRIPTION
If the json of the JWT is invalid, an exeption is thrown that breaks our flow.
This patch changes that by catching it and returning a proper result.