### PR TITLE
Add self-approver utility and board-member to expenses rules

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clanhr/auth "1.24.0"
+(defproject clanhr/auth "1.25.0"
   :description "ClanHR's Auth Library"
   :url "https://github.com/clanhr/auth"
   :license {:name "The MIT License"

--- a/src/clanhr/auth/authorization_rules.clj
+++ b/src/clanhr/auth/authorization_rules.clj
@@ -23,7 +23,7 @@
    :can-mark-account-as-paid (:developer-member profile)
    :change-absence-state (conj (:board-member profile) "approver")
    :change-expense-state (conj (:board-member profile) "approver")
-   :can-auto-approve-expenses ["approver"]
+   :can-auto-approve-expenses (conj (:board-member profile) "approver")
    :settings-access (:board-member profile)
    :can-see-full-user-info (:board-member profile)
    :delete-user (:board-member profile)

--- a/src/clanhr/auth/roles_for.clj
+++ b/src/clanhr/auth/roles_for.clj
@@ -11,9 +11,23 @@
             (some #{user-id} (get-in other-user [:company-data :manager-ids])))
       "approver")))
 
+(defn self-approver
+  "If the user is the same as other-user and the user is approver of himself,
+   returns the self-approver role"
+  [user other-user]
+  (if-let [user-id (:_id user)]
+    (when (and (= user-id (:_id other-user))
+             (some #{user-id} (get-in user [:company-data :manager-ids])))
+      "self-approver")))
+
+(defn get-roles
+  [user other-user]
+  (conj [(approver user other-user)]
+         (self-approver user other-user)))
+
 (defn run
   "Returns specific roles that represent the relation between user and other-user"
   [{:keys [user other-user]}]
-  (->> [(approver user other-user)]
+  (->> (get-roles user other-user)
        (filter identity)
        (result/success)))

--- a/test/clanhr/auth/roles_for_test.clj
+++ b/test/clanhr/auth/roles_for_test.clj
@@ -15,6 +15,16 @@
       (is (= "approver" (roles-for/approver user other-user)))
       (is (= nil (roles-for/approver other-user user))))))
 
+(deftest self-approver
+  (testing "should be self approver"
+    (let [user {:_id "1" :company-data {:manager-ids ["1"]}}
+          other-user {:_id "1"}]
+      (is (= "self-approver" (roles-for/self-approver user other-user)))))
+  (testing "should not be self approver"
+    (let [user {:_id "1" :company-data {:manager-ids ["2"]}}
+          other-user {:_id "2"}]
+      (is (= nil (roles-for/self-approver user other-user))))))
+
 (deftest run-test
   (let [user {:_id "1"}
         other-user {:company-data {:manager-ids ["1"]}}


### PR DESCRIPTION
- Add self-approver utility. This utility receives 2 users and checks if
  they are the same, if they are the same checks if the user is it's own
  approver

  - Add a board-member to expenses rules