### PR TITLE
Fix self-approver role

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clanhr/auth "1.25.0"
+(defproject clanhr/auth "1.26.0"
   :description "ClanHR's Auth Library"
   :url "https://github.com/clanhr/auth"
   :license {:name "The MIT License"

--- a/src/clanhr/auth/roles_for.clj
+++ b/src/clanhr/auth/roles_for.clj
@@ -17,7 +17,7 @@
   [user other-user]
   (if-let [user-id (:_id user)]
     (when (and (= user-id (:_id other-user))
-             (some #{user-id} (get-in user [:company-data :manager-ids])))
+             (= user-id (get-in user [:company-data :approver-id])))
       "self-approver")))
 
 (defn get-roles

--- a/test/clanhr/auth/roles_for_test.clj
+++ b/test/clanhr/auth/roles_for_test.clj
@@ -17,9 +17,13 @@
 
 (deftest self-approver
   (testing "should be self approver"
-    (let [user {:_id "1" :company-data {:manager-ids ["1"]}}
+    (let [user {:_id "1" :company-data {:manager-ids ["2"] :approver-id "1"}}
           other-user {:_id "1"}]
       (is (= "self-approver" (roles-for/self-approver user other-user)))))
+  (testing "should not be self approver"
+    (let [user {:_id "1" :company-data {:manager-ids ["1"] :approver-id "2"}}
+          other-user {:_id "1"}]
+      (is (= nil (roles-for/self-approver user other-user)))))
   (testing "should not be self approver"
     (let [user {:_id "1" :company-data {:manager-ids ["2"]}}
           other-user {:_id "2"}]
@@ -31,4 +35,3 @@
         result (roles-for/run {:user user :other-user other-user})]
     (is (result/succeeded? result))
     (is (= ["approver"] (:data result)))))
-


### PR DESCRIPTION
**Problem:**
[I created an expense but it was created approved > WRONG. The expense must be created as pending because I have a manager](https://app.liquidplanner.com/space/173188/projects/show/37047222)

Account: bruna.nezello+803@rupeal.com (Admin, Manager and HR)
12345 ou 123456
My manager is Sandra.

So, I added an absence. It was created pending > PERFECT.
But, I created an expense but it was created approved > WRONG. The correct is the same in absence. The expense must be created, because I have a manager, as pending.

**Why:**
It happens because Bruna is manager of Sandra. So on hierarchy of managers, Bruna is included on her managers.

**Solutions:**
Change the premise, the self-approver role only looks for the approver-id. So if the user is the same as other-user and the user is approver of himself,
   returns the self-approver role

If the user is the same as other-user and the user is approver of himself, returns the self-approver role.