### PR TITLE
Add "deactivate user" auth rule

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,2 @@
 language: clojure
-lein: lein2
+lein: lein

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clanhr/auth "1.26.0"
+(defproject clanhr/auth "1.27.0"
   :description "ClanHR's Auth Library"
   :url "https://github.com/clanhr/auth"
   :license {:name "The MIT License"

--- a/src/clanhr/auth/authorization_rules.clj
+++ b/src/clanhr/auth/authorization_rules.clj
@@ -35,6 +35,7 @@
    :settings-access (:board-member profile)
    :can-see-full-user-info (:board-member profile)
    :delete-user (:board-member profile)
+   :deactivate-user (:board-member profile)
    :billing-actions-access (:administrator-member profile)})
 
 (defn run

--- a/test/clanhr/auth/authorization_rules_test.clj
+++ b/test/clanhr/auth/authorization_rules_test.clj
@@ -21,7 +21,9 @@
     (is (result/succeeded?
           (authorization-rules/run :notifications-access "")))
     (is (result/succeeded?
-          (authorization-rules/run :notifications-access ["admin" "hrmanager"]))))
+          (authorization-rules/run :notifications-access ["admin" "hrmanager"])))
+    (is (result/succeeded?
+          (authorization-rules/run :deactivate-user ["admin" "hrmanager"]))))
 
   (testing "do not have access"
     (is (result/forbidden?
@@ -29,4 +31,6 @@
     (is (result/forbidden?
           (authorization-rules/run :reports-access nil)))
     (is (result/forbidden?
-          (authorization-rules/run :reports-access "")))))
+          (authorization-rules/run :reports-access "")))
+    (is (result/forbidden?
+          (authorization-rules/run :deactivate-user ["manager" "" nil])))))


### PR DESCRIPTION
Why:

* So we can validate which roles can deactivate a user

This change addresses the need by:

* Adding the "deactivate-user" rule only for board-members.