### PR TITLE
Add new 'expensesManager' role to expenses rules

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clanhr/auth "1.27.0"
+(defproject clanhr/auth "1.28.0"
   :description "ClanHR's Auth Library"
   :url "https://github.com/clanhr/auth"
   :license {:name "The MIT License"

--- a/src/clanhr/auth/authorization_rules.clj
+++ b/src/clanhr/auth/authorization_rules.clj
@@ -17,6 +17,9 @@
    :developer-member ["developer"]
    :administrator-member ["admin" "hrmanager"]})
 
+(def ^:const approver "approver")
+(def ^:const expenses-manager "expensesManager")
+
 (def ^:const rules
   "Maps specific actions or zones to allowed roles"
   {:directory-access (:full-access profile)
@@ -29,9 +32,9 @@
    :can-manage-alerts (:board-member profile)
    :can-manage-holidays (:board-member profile)
    :can-mark-account-as-paid (:developer-member profile)
-   :change-absence-state (conj (:board-member profile) "approver")
-   :change-expense-state (conj (:board-member profile) "approver")
-   :can-auto-approve-expenses (conj (:board-member profile) "approver")
+   :change-absence-state (conj (:board-member profile) approver)
+   :change-expense-state (conj (:board-member profile) approver expenses-manager)
+   :can-auto-approve-expenses (conj (:board-member profile) approver expenses-manager)
    :settings-access (:board-member profile)
    :can-see-full-user-info (:board-member profile)
    :delete-user (:board-member profile)

--- a/test/clanhr/auth/authorization_rules_test.clj
+++ b/test/clanhr/auth/authorization_rules_test.clj
@@ -23,7 +23,11 @@
     (is (result/succeeded?
           (authorization-rules/run :notifications-access ["admin" "hrmanager"])))
     (is (result/succeeded?
-          (authorization-rules/run :deactivate-user ["admin" "hrmanager"]))))
+          (authorization-rules/run :deactivate-user ["admin" "hrmanager"])))
+    (is (result/succeeded?
+          (authorization-rules/run :change-expense-state ["expensesManager"])))
+    (is (result/succeeded?
+          (authorization-rules/run :can-auto-approve-expenses ["expensesManager"]))))
 
   (testing "do not have access"
     (is (result/forbidden?


### PR DESCRIPTION
Why:

* So a user with this role can manage company expenses.

This change addresses the need by:

* Adding the 'expensesManager' role to the following rules:
  - change-expense-state
  - can-auto-approve-expenses