### PR TITLE
Allow 'absencesManager' to access reports

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clanhr/auth "1.28.0"
+(defproject clanhr/auth "1.29.0"
   :description "ClanHR's Auth Library"
   :url "https://github.com/clanhr/auth"
   :license {:name "The MIT License"

--- a/src/clanhr/auth/authorization_rules.clj
+++ b/src/clanhr/auth/authorization_rules.clj
@@ -19,12 +19,13 @@
 
 (def ^:const approver "approver")
 (def ^:const expenses-manager "expensesManager")
+(def ^:const absences-manager "absencesManager")
 
 (def ^:const rules
   "Maps specific actions or zones to allowed roles"
   {:directory-access (:full-access profile)
    :notifications-access (:full-access profile)
-   :reports-access (:board-member-manager profile)
+   :reports-access (conj (:board-member-manager profile) absences-manager)
    :can-manage-groups (:board-member-manager profile)
    :can-manage-absences (:board-member profile)
    :can-manage-roles (:board-member profile)

--- a/test/clanhr/auth/authorization_rules_test.clj
+++ b/test/clanhr/auth/authorization_rules_test.clj
@@ -27,7 +27,9 @@
     (is (result/succeeded?
           (authorization-rules/run :change-expense-state ["expensesManager"])))
     (is (result/succeeded?
-          (authorization-rules/run :can-auto-approve-expenses ["expensesManager"]))))
+          (authorization-rules/run :can-auto-approve-expenses ["expensesManager"])))
+    (is (result/succeeded?
+          (authorization-rules/run :reports-access ["absencesManager"]))))
 
   (testing "do not have access"
     (is (result/forbidden?


### PR DESCRIPTION
Why:

* So a user with this role can access reports.

This change addresses the need by:

* Adding the 'absencesManager' role to the 'reports-access' rule.