### PR TITLE
Allow expensesManager to access settings

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clanhr/auth "1.30.0"
+(defproject clanhr/auth "1.31.0"
   :description "ClanHR's Auth Library"
   :url "https://github.com/clanhr/auth"
   :license {:name "The MIT License"

--- a/src/clanhr/auth/authorization_rules.clj
+++ b/src/clanhr/auth/authorization_rules.clj
@@ -36,7 +36,7 @@
    :change-absence-state (conj (:board-member profile) approver absences-manager)
    :change-expense-state (conj (:board-member profile) approver expenses-manager)
    :can-auto-approve-expenses (conj (:board-member profile) approver expenses-manager)
-   :settings-access (conj (:board-member profile) absences-manager)
+   :settings-access (conj (:board-member profile) absences-manager expenses-manager)
    :can-see-full-user-info (:board-member profile)
    :delete-user (:board-member profile)
    :deactivate-user (:board-member profile)

--- a/test/clanhr/auth/authorization_rules_test.clj
+++ b/test/clanhr/auth/authorization_rules_test.clj
@@ -31,7 +31,7 @@
     (is (result/succeeded?
           (authorization-rules/run :reports-access ["absencesManager"])))
     (is (result/succeeded?
-          (authorization-rules/run :settings-access ["absencesManager"])))
+          (authorization-rules/run :settings-access ["absencesManager" "expensesManager"])))
     (is (result/succeeded?
           (authorization-rules/run :can-manage-absences ["absencesManager"])))
     (is (result/succeeded?


### PR DESCRIPTION
Why:

* So an expensesManager can access and edit the general settings.

This change addresses the need by:

* Adding the expensesManager to the 'settings-access' rule.