### PR TITLE
Allow self-approver to approve pending expenses

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clanhr/auth "1.31.0"
+(defproject clanhr/auth "1.32.0"
   :description "ClanHR's Auth Library"
   :url "https://github.com/clanhr/auth"
   :license {:name "The MIT License"

--- a/src/clanhr/auth/authorization_rules.clj
+++ b/src/clanhr/auth/authorization_rules.clj
@@ -18,6 +18,7 @@
    :administrator-member ["admin" "hrmanager"]})
 
 (def ^:const approver "approver")
+(def ^:const self-approver "self-approver")
 (def ^:const expenses-manager "expensesManager")
 (def ^:const absences-manager "absencesManager")
 
@@ -35,7 +36,7 @@
    :can-mark-account-as-paid (:developer-member profile)
    :change-absence-state (conj (:board-member profile) approver absences-manager)
    :change-expense-state (conj (:board-member profile) approver expenses-manager)
-   :can-auto-approve-expenses (conj (:board-member profile) approver expenses-manager)
+   :can-auto-approve-expenses (conj (:board-member profile) approver self-approver expenses-manager)
    :settings-access (conj (:board-member profile) absences-manager expenses-manager)
    :can-see-full-user-info (:board-member profile)
    :delete-user (:board-member profile)

--- a/test/clanhr/auth/authorization_rules_test.clj
+++ b/test/clanhr/auth/authorization_rules_test.clj
@@ -29,6 +29,8 @@
     (is (result/succeeded?
           (authorization-rules/run :can-auto-approve-expenses ["expensesManager"])))
     (is (result/succeeded?
+          (authorization-rules/run :can-auto-approve-expenses ["self-approver"])))
+    (is (result/succeeded?
           (authorization-rules/run :reports-access ["absencesManager"])))
     (is (result/succeeded?
           (authorization-rules/run :settings-access ["absencesManager" "expensesManager"])))


### PR DESCRIPTION
Why:

* If a self-approver has a pending expense, he/she should be able to approve it.

This change addresses the need by:

* Allowing a self-approver on the rule :can-auto-approve-expenses.